### PR TITLE
Feedreader 1.6 beta1 needs libsecret to be build with USE=vala

### DIFF
--- a/net-news/feedreader/feedreader-1.6_beta1.ebuild
+++ b/net-news/feedreader/feedreader-1.6_beta1.ebuild
@@ -35,7 +35,7 @@ RDEPEND=">=x11-libs/gtk+-3.12:3
 	net-libs/libsoup:2.4
 	dev-libs/gobject-introspection
 	dev-db/sqlite:3
-	app-crypt/libsecret
+	app-crypt/libsecret[vala]
 	x11-libs/libnotify
 	dev-libs/libxml2
 	net-libs/rest:0.7


### PR DESCRIPTION
Did not check for the older versions, only for 1.6 beta1